### PR TITLE
Fixed Auto Fan Speed setting not available for some users

### DIFF
--- a/custom_components/actronair_neo/climate.py
+++ b/custom_components/actronair_neo/climate.py
@@ -97,6 +97,8 @@ class ActronClimate(ActronEntityBase, ClimateEntity):
         """Return the list of available fan modes based on model capabilities."""
         try:
             model = self.coordinator.data["main"].get("model")
+            if "NTB" in model or "NTW" in model:
+                model = self.coordinator.data["main"].get("indoor_model")
             supported_modes = self.coordinator.api._validate_fan_modes(
                 self.coordinator.data["main"].get("supported_fan_modes", 0),
                 model
@@ -198,6 +200,8 @@ class ActronClimate(ActronEntityBase, ClimateEntity):
             
             # Check model support for AUTO mode
             model = self.coordinator.data["main"].get("model")
+            if "NTB" in model or "NTW" in model:
+                model = self.coordinator.data["main"].get("indoor_model")
             if actron_mode == "AUTO" and model not in ADVANCE_SERIES_MODELS:
                 _LOGGER.warning(
                     "Cannot set AUTO fan mode on model %s (Advance Series only)",

--- a/custom_components/actronair_neo/coordinator.py
+++ b/custom_components/actronair_neo/coordinator.py
@@ -374,16 +374,16 @@ class ActronDataCoordinator(DataUpdateCoordinator):
 
                 # Process bitmap
                 supported = []
-                if modes & 1:
+                if modes >= 1:
                     supported.append("LOW")
                     _LOGGER.debug("Added LOW mode (bit 0 set)")
-                if modes & 2:
+                if modes >= 2:
                     supported.append("MED")
                     _LOGGER.debug("Added MED mode (bit 1 set)")
-                if modes & 4:
+                if modes >= 4:
                     supported.append("HIGH")
                     _LOGGER.debug("Added HIGH mode (bit 2 set)")
-                if modes & 8:
+                if modes == 8:
                     auto_enabled = False
                     if hasattr(self, 'data') and self.data is not None:
                         indoor_unit = self.data.get("raw_data", {}


### PR DESCRIPTION
Added case for WCModel returning NTB-10 or NTW-10.
Fixed Bitmap to return a supported list instead of single mode
Added case if Auto is available and AutoModeEnabled but SupportedFanModes returns 4 not 8.
Fixed mapping for CurrentMode and AutoEnabled