### PR TITLE
chore(ci): modernize dependabot.yml and fix shellcheck warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,14 +45,21 @@ updates:
       include: "scope"
     groups:
       production-minor-patch:
-        dependency-type: "production"
+        patterns:
+          - "homeassistant"
+          - "colorlog"
         update-types:
           - "minor"
           - "patch"
-      dev-dependencies:
-        dependency-type: "development"
+      dev-minor-patch:
         patterns:
           - "*"
+        exclude-patterns:
+          - "homeassistant"
+          - "colorlog"
+        update-types:
+          - "minor"
+          - "patch"
     cooldown:
       default-days: 3
       semver-major-days: 7

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -10,5 +10,5 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v6"
-      - uses: "home-assistant/actions/hassfest@master"
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+      - uses: "home-assistant/actions/hassfest@dce0e860c68256ef2902ece06afa5401eb4674e1" # master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,7 +263,9 @@ jobs:
         if: always()
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          cat >> "$GITHUB_STEP_SUMMARY" << EOF
+
+          if [ "${{ job.status }}" = "success" ]; then
+            cat >> "$GITHUB_STEP_SUMMARY" << EOF
           ## 🎉 v${VERSION} Released Successfully!
 
           **Package:** \`${{ steps.build.outputs.package }}\`
@@ -281,3 +283,13 @@ jobs:
           - ✅ HACS users can now update to v${VERSION}
           - ✅ Manual installation package available for download
           EOF
+          else
+            cat >> "$GITHUB_STEP_SUMMARY" << EOF
+          ## ❌ v${VERSION} Release Failed
+
+          The release workflow did not complete successfully.
+          Check the job logs above for details.
+
+          **Status:** ${{ job.status }}
+          EOF
+          fi

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,6 +15,6 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: HACS Action
-        uses: "hacs/action@main"
+        uses: "hacs/action@dcb30e72781db3f207d5236b861172774ab0b485" # main
         with:
           category: "integration"


### PR DESCRIPTION
## Summary

Modernizes the Dependabot configuration to 2026 best practices and fixes shellcheck warnings in the release workflow.

### dependabot.yml improvements
1. **`pip` → `uv` ecosystem** — native uv support matches our `[tool.uv]` / `[dependency-groups]` in pyproject.toml
2. **Dependency groups** — GitHub Actions minor+patch batched; uv production minor+patch grouped, all dev deps grouped
3. **Conventional commit prefixes** — `chore(deps):` with `include: scope` for consistent PR titles
4. **Schedule tuning** — devcontainers: monthly, github-actions: weekly, uv: weekly (was all daily)
5. **Labels** — `dependencies` on all PRs, plus ecosystem-specific labels
6. **Cooldown** — 3-day default on uv patches, 7-day on majors to avoid rapid-fire releases

### release.yml fixes
- Quoted all `$GITHUB_OUTPUT` and `$GITHUB_STEP_SUMMARY` references (13 shellcheck SC2086 warnings)

### Validation
- **actionlint** v1.7.11 + **shellcheck**: 0 errors across all 3 workflows
- **Schema validation**: all dependabot.yml fields validated against GitHub docs
- All pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to refine dependency update schedules and add structured commit messages for dependency updates across multiple ecosystems.
  * Enhanced release workflow with automated version tagging, build provenance attestation, and comprehensive release notes generation.
  * Added HACS validation workflow for automated repository quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->