### PR TITLE
Bump version from 2026.3.0 to 2026.3.1

### DIFF
--- a/custom_components/actronair_neo/manifest.json
+++ b/custom_components/actronair_neo/manifest.json
@@ -10,6 +10,6 @@
   "issue_tracker": "https://github.com/ruaan-deysel/ha-actronair-neo/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "2026.3.0",
+  "version": "2026.3.1",
   "zeroconf": []
 }


### PR DESCRIPTION
Bump version from 2026.3.0 to 2026.3.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2026.3.1 with no functional changes or impact on existing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->